### PR TITLE
Add README notes and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Jenny Long and Tom Russell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # SSI-mentorship
+
+This is a project that will consist of analysis of some data (to be decided).
+
+
+## License
+
+Code is licensed under the MIT License
+
+Copyright (c) 2023 Jenny Long and Tom Russell
+
+
+## Acknowledgments
+
+Thanks to the Software Sustainability Institute for organising and supporting the mentorship programme.


### PR DESCRIPTION
This pull request:
- adds a couple of brief notes to the README, acknowledging the SSI mentorship scheme - see https://github.com/matiassingers/awesome-readme for some inspirational examples and https://www.freecodecamp.org/news/how-to-write-a-good-readme-file/ for a nice short article on writing READMEs.
- adds the MIT license in a LICENSE file, and notes it in the README - see https://choosealicense.com/ for common options and guidance around open licensing